### PR TITLE
Fix typo in self check

### DIFF
--- a/foundations/02-class-id-selectors/README.md
+++ b/foundations/02-class-id-selectors/README.md
@@ -17,6 +17,6 @@ Quick tip: in VS Code, you can change which format colors are displayed in (RGB,
 
 
 ### Self Check
-- Do the odd numbered `div` elements share a class?
+- Do the odd numbered `p` elements share a class?
 - Do the even numbered `div` elements have unique ID's?
 - Does the 3rd `div` element have multiple classes?


### PR DESCRIPTION
Should refer to `p` instead of `div` for the odd numbered elements