### PR TITLE
Fix typo in README.md

### DIFF
--- a/foundations/02-class-id-selectors/README.md
+++ b/foundations/02-class-id-selectors/README.md
@@ -19,4 +19,4 @@ Quick tip: in VS Code, you can change which format colors are displayed in (RGB,
 ### Self Check
 - Do the odd numbered `p` elements share a class?
 - Do the even numbered `div` elements have unique ID's?
-- Does the 3rd `div` element have multiple classes?
+- Does the 2nd `p` element have multiple classes?


### PR DESCRIPTION
The html code doesn't have a 3rd div element, it's supposed to be the 2nd `p` element.