### PR TITLE
Fix wrong instruction in readme

### DIFF
--- a/margin-and-padding/margin-and-padding-1/README.md
+++ b/margin-and-padding/margin-and-padding-1/README.md
@@ -1,6 +1,6 @@
 # Margin and Padding practice
 
-For this first exercise, simply edit the `index.html` file so that the divs look like the image below. Only edit the CSS where instructed in the file.  You should only have to change the values of the margin and padding for this exercise. You should not have to add or remove properties in the CSS, or touch the HTML.
+For this first exercise, only edit the CSS where instructed in the file. You should only have to change the values of the margin and padding for this exercise. You should not have to add or remove properties in the CSS, or touch the HTML.
 
 ![outcome](./desired-outcome.png)
 


### PR DESCRIPTION
In `margin-and-padding-1`'s readme, there is a sentence like below.

> simply edit the `index.html` file so that the divs look like the image 

There is no need to touch `index.html`.
```sh
diff margin-and-padding/margin-and-padding-1/index.html \
     margin-and-padding/margin-and-padding-1/solution/solution.html
```
The result of above is
```diff
<   <link rel="stylesheet" href="style.css">
---
>   <link rel="stylesheet" href="solution.css">

```
