### PR TITLE
Correction to self-check list in README

### DIFF
--- a/foundations/02-class-id-selectors/README.md
+++ b/foundations/02-class-id-selectors/README.md
@@ -19,4 +19,4 @@ Quick tip: in VS Code, you can change which format colors are displayed in (RGB,
 ### Self Check
 - Do the odd numbered `p` elements share a class?
 - Do the even numbered `div` elements have unique ID's?
-- Does the 3rd `div` element have multiple classes?
+- Does the 2nd `p` element have multiple classes?


### PR DESCRIPTION
Instead of "...3rd `div`", wouldn't the correct interpretation to the README be, "...2nd `p`" while referencing to the HTML file in lesson 02 (foundations/02-class-id-selectors)?

I was initially confused when comparing my changes with the self-checklist in reference to the self-checklist while doing the assignment and thought I'd make it clearer for myself/others.