### PR TITLE
Fixing an issue regarding card size

### DIFF
--- a/flex/07-flex-layout-2/README.md
+++ b/flex/07-flex-layout-2/README.md
@@ -28,5 +28,6 @@ on a smaller screen it will look like this:
 - Sidebar is 300px wide (i.e. it doesn't shrink)
 - Sidebar links are size 24px, white and do not have the underline text decoration.
 - Sidebar has 16px padding.
+- Cards are 300px wide (i.e. it doesn't shrink).
 - There is 32px padding around the 'cards' section
 - Cards are arranged horizontally, but wrap to multiple lines when they run out of room on the page

--- a/flex/07-flex-layout-2/solution/solution.css
+++ b/flex/07-flex-layout-2/solution/solution.css
@@ -25,7 +25,6 @@ body {
   border: 1px solid #eee;
   box-shadow: 2px 4px 16px rgba(0,0,0,.06);
   border-radius: 4px;
-  width: 300px;
 }
 
 /* SOLUTION */
@@ -78,6 +77,7 @@ a {
 .card {
   padding: 16px;
   margin: 16px;
+  width: 300px;
 }
 
 .footer {


### PR DESCRIPTION
There is a `width: 300px` rule for the original .card selector in the solution css file. However it's not there in the main(the one we modify to solve the exercise). So I thought it belonged to solution and moved there. I also added that info to the "Self Check" section in the README.md so that people could solve without looking to solution.