### PR TITLE
Misplaced width ellement added after solving

### DIFF
--- a/flex/07-flex-layout-2/solution/solution.css
+++ b/flex/07-flex-layout-2/solution/solution.css
@@ -25,7 +25,6 @@ body {
   border: 1px solid #eee;
   box-shadow: 2px 4px 16px rgba(0,0,0,.06);
   border-radius: 4px;
-  width: 300px;
 }
 
 /* SOLUTION */
@@ -78,6 +77,7 @@ a {
 .card {
   padding: 16px;
   margin: 16px;
+  width: 300px;
 }
 
 .footer {


### PR DESCRIPTION
In the exercise Style.css, there was no width element added on the .card selector.
it's only added in the solution, so I think the width element should be moved to under the solution line.