### PR TITLE
Added missing width rule to .card

### DIFF
--- a/flex/07-flex-layout-2/style.css
+++ b/flex/07-flex-layout-2/style.css
@@ -25,4 +25,5 @@ body {
   border: 1px solid #eee;
   box-shadow: 2px 4px 16px rgba(0,0,0,.06);
   border-radius: 4px;
+  width: 300px;
 }


### PR DESCRIPTION
According to solutions.css of this exercise, width: 300px; is supposed to be included in .card's rules.
Maybe the rule is supposed to be added inside the solution area of the solutions.css instead?