### PR TITLE
Remove unnecessary whitespace

### DIFF
--- a/foundations/06-cascade-fix/style.css
+++ b/foundations/06-cascade-fix/style.css
@@ -16,7 +16,7 @@
   color: white;
   font-size: 20px;
   font-weight: bold;
-} 
+}
 
 .button {
   background-color: #ffc0cb;


### PR DESCRIPTION
There's a space after a `}` in styles.css of `foundations/06-cascade-fix`