### PR TITLE
Remove hyphens from 04-chaining-selectors/index.html.

### DIFF
--- a/foundations/04-chaining-selectors/index.html
+++ b/foundations/04-chaining-selectors/index.html
@@ -15,8 +15,8 @@
   </div>
   <!-- Use the classes ABOVE this line -->
   <div>
-    <img class="original-proportioned" src="./pexels-katho-mutodo-8434791.jpg" alt="">
-    <img class="original-distorted" src="./pexels-andrea-piacquadio-3777931.jpg" alt="">
+    <img class="original proportioned" src="./pexels-katho-mutodo-8434791.jpg" alt="">
+    <img class="original distorted" src="./pexels-andrea-piacquadio-3777931.jpg" alt="">
   </div>
 </body>
 </html>

--- a/foundations/04-chaining-selectors/solution/solution.html
+++ b/foundations/04-chaining-selectors/solution/solution.html
@@ -13,8 +13,8 @@
     <img class="avatar distorted" src="../pexels-andrea-piacquadio-3777931.jpg" alt="">
   </div>
   <div>
-    <img class="original-proportioned" src="../pexels-katho-mutodo-8434791.jpg" alt="">
-    <img class="original-distorted" src="../pexels-andrea-piacquadio-3777931.jpg" alt="">
+    <img class="original proportioned" src="../pexels-katho-mutodo-8434791.jpg" alt="">
+    <img class="original distorted" src="../pexels-andrea-piacquadio-3777931.jpg" alt="">
   </div>
 </body>
 </html>


### PR DESCRIPTION
Classes must now be chained properly to reach the desired outcome.