### PR TITLE
Fixed a typo at margin-and-padding-2/README.md

### DIFF
--- a/margin-and-padding/margin-and-padding-2/README.md
+++ b/margin-and-padding/margin-and-padding-2/README.md
@@ -13,6 +13,6 @@ Use this section to check your work. On _these_ projects, your goal isn't to att
 - The title of the card uses a 16px font.
 - There are 8px between the title text and the edge of the title section.
 - The content section has 16px space on the top and bottom, and 8px on either side.
-- Everything inside the `.button` section is centered, and there is 8px padding.
+- Everything inside the `.button-container` section is centered, and there is 8px padding.
 - The Big Button is centered on its own line.
 - The Big Button has 24px space on the sides, and 8px on top and bottom.


### PR DESCRIPTION
`.button` was been changed to `.button-container`, but the readme file was not changed.