### PR TITLE
Remove redundant line

### DIFF
--- a/flex/03-flex-header-2/solution/solution.css
+++ b/flex/03-flex-header-2/solution/solution.css
@@ -52,7 +52,6 @@ ul {
 .header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
   padding: 8px;
 }
 


### PR DESCRIPTION
In this case, all elements are either in the .left or the .right container. The alignment is correctly set on the corresponding class, but also set on the header which might be misleading.