### PR TITLE
Foundations-002 Added Linux-compatible font

### DIFF
--- a/foundations/02-class-id-selectors/README.md
+++ b/foundations/02-class-id-selectors/README.md
@@ -5,7 +5,7 @@ There are several elements in the HTML file provided, which you will have to add
 
 It isn't entirely important which class or ID values you use, as the focus here is on being able to add the attributes and use the correct selector syntax to style elements. For the colors in this exercise, try using a non-keyword value (RGB, HEX, or HSL). The properties you need to add to each element are:
 
-* **All odd numbered elements**: a light red/pink background, and a list of fonts containing `Verdana` as the first option and `sans-serif` as a fallback
+* **All odd numbered elements**: a light red/pink background, and a list of fonts containing `Verdana` and `DejaVu Sans` with `sans-serif` as a fallback
 * **The second element**: blue text and a font size of 36px
 * **The third element**: in addition to the styles for all odd numbered elements, add a font size of 24px
 * **The fourth element**: a light green background, a font size of 24px, and bold

--- a/foundations/02-class-id-selectors/solution/solution.css
+++ b/foundations/02-class-id-selectors/solution/solution.css
@@ -1,6 +1,6 @@
 .odd {
   background-color: rgb(255, 167, 167);
-  font-family: Verdana, sans-serif;
+  font-family: Verdana, DejaVu Sans, sans-serif;
 }
 
 .oddly-cool {


### PR DESCRIPTION
On Ubuntu 20.04.3 LTS with Firefox, the Verdana font isn't present.

The suggested sans serif font `DejaVu Sans` is commonly deployed as standard within popular Linux distributions such as Ubuntu, Debian, Fedora, and RHEL so should provide good usability.

I appreciate the CSS falls back to the system standard font for 'sans serif' if the named font isn't found, however specifying a font actually present on the system makes for a better learning experience on this occasion.

This could be a good example for future web developers, for consideration that the end-user of their web pages in real life might not be using the same OS/browser combination as them.
