### PR TITLE
07 flex layout 2: add additional hint for cards requiring space

### DIFF
--- a/flex/07-flex-layout-2/README.md
+++ b/flex/07-flex-layout-2/README.md
@@ -8,7 +8,7 @@ As with the previous exercise, we've left a little more for you to do.
 - You will need to change the flex-direction to push the footer down.
 - You will need to add some divs as containers to get things to line up correctly.
 - `flex-wrap` will help get the cards aligned correctly.
--  Make sure cards know how much space they should take for `flex-wrap` to work correctly.
+-  Make sure cards know how much space they should take for `flex-wrap` to work as intended.
 
 ## Desired outcome
 

--- a/flex/07-flex-layout-2/README.md
+++ b/flex/07-flex-layout-2/README.md
@@ -8,7 +8,7 @@ As with the previous exercise, we've left a little more for you to do.
 - You will need to change the flex-direction to push the footer down.
 - You will need to add some divs as containers to get things to line up correctly.
 - `flex-wrap` will help get the cards aligned correctly.
--  Make sure cards know how much space they should take for `flex-wrap` to work as intended.
+-  Make sure you define how much space the cards should take up, in order for `flex-wrap` to work as intended.
 
 ## Desired outcome
 

--- a/flex/07-flex-layout-2/README.md
+++ b/flex/07-flex-layout-2/README.md
@@ -6,8 +6,9 @@ As with the previous exercise, we've left a little more for you to do.
 
 ### Hints
 - You will need to change the flex-direction to push the footer down.
-- You will need to add some divs as containers to get things to line up correctly. 
+- You will need to add some divs as containers to get things to line up correctly.
 - `flex-wrap` will help get the cards aligned correctly.
+-  Make sure cards know how much space they should take for `flex-wrap` to work correctly.
 
 ## Desired outcome
 


### PR DESCRIPTION
<!--
Thank you for taking the time to contribute to The Odin Project. In order to get pull requests (PRs) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please complete all applicable checkboxes (replace the whitespace between the square brackets with an 'x', e.g. [x]) and answer the following triage questions:
-->

- [x] I have thoroughly read the [CSS Exercises Contributing Guide](https://github.com/TheOdinProject/css-exercises/blob/main/CONTRIBUTING.md)
- [x] The title of this PR is in `file/exercise/folder: brief description of changes` format e.g. `01 flex center: add hint for XYZ`
- [x] If one exists, I have linked a related open issue to this PR by replacing `XXXXX` in Step 2 below with the issue number, e.g. `#2013`
- [ ] If changes were requested, I have made them in a timely manner and re-requested a review from the maintainer (top of the right sidebar)

**1. Description of the Changes**

I have added a hint about `.card` divs requiring their space to be defined so `wrap` works as intended. In this case it is going to be defining `width` property of them because of `flex-direction: row` of the container as asked in the Self-Check. 

I realize that the original issue asked for including in the self-check section:
* Ensure each card has a width of 300px

but I believe that might make people miss out on understanding why defining this space is needed. Instead of leaving learners with "it worked with cards being 300px! hooray!" I'd rather have people leave with "for wrap to work I need to tell it when to wrap and that means telling the items how much space they should take." 
Hopefully this is still in scope of this issue, I will gladly only introduce the suggested change if that is not the case.

**2. Related Issue**

Closes #88 