### PR TITLE
Fixed typo in grid-layout-2 exercise

### DIFF
--- a/grid/02-grid-layout-2/README.md
+++ b/grid/02-grid-layout-2/README.md
@@ -21,7 +21,7 @@ When the browser is stretched wide:
 - The grid has two columns
 - The grid has four rows
 - The grid tracks do not use static sizes (no pixels!)
-- The first column is three times larger than the other
+- The second column is three times larger than the other
 - The third row is five times larger than the others
 - The rows and columns stretch wider when making the browser window bigger
 - The rows and columns stretch taller when making the browser window smaller


### PR DESCRIPTION
- [x] I have thoroughly read and understand the [CSS Exercises Contributing Guide](https://github.com/TheOdinProject/css-exercises/blob/main/CONTRIBUTING.md)
- [x] The title of this PR is in `file/exercise/folder: brief description of changes` format e.g. `01 flex center: add hint for XYZ`

<!-- Complete the following checkboxes only if they are applicable to your PR. You can complete these later if they are not currently applicable. -->
- [ ] If one exists, I have linked a related open issue to this PR in Step 2 below
- [ ] If changes were requested, I have made them and re-requested a review from the maintainer (top of the right sidebar)

**1. Description of the Changes**
The desired-outcome.png shows a layout where the second column is three times larger than the first column. The README's Self Check portion has the two column sizes listed backwards.