### PR TITLE
02-class-id-selectors: Fix improper font-family syntax

### DIFF
--- a/foundations/02-class-id-selectors/solution/solution.css
+++ b/foundations/02-class-id-selectors/solution/solution.css
@@ -1,6 +1,6 @@
 .odd {
   background-color: rgb(255, 167, 167);
-  font-family: Verdana, DejaVu Sans, sans-serif;
+  font-family: Verdana, "DejaVu Sans", sans-serif;
 }
 
 .oddly-cool {


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [ ] I have ensured that the TOP solution files match the Desired Outcome image

<hr>

**1. Because:**

Font names with whitespace should be put in quotes as per good practice recommended by TOP. This isn't the case here with `DejaVu Sans`.

Closes #132 


**2. This PR:**

* Adds quotes to `DejaVu Sans` font 

**3. Additional Information:**

