### PR TITLE
Easy Fix - css-exercises/foundation/06 cascade fix/solution/style.css -Typo and line wrap

### DIFF
--- a/foundations/06-cascade-fix/solution/solution.css
+++ b/foundations/06-cascade-fix/solution/solution.css
@@ -32,7 +32,7 @@ div.text {
   Another solution would be keeping it in its original place and just chaining selectors, giving this rule a higher specificity:
 
   p.small-para {
-    font-size: 12px;
+    font-size: 14px;
   }
 */
 
@@ -74,7 +74,8 @@ div.text {
     font-size: 14px;
   }
 
-  Then we added another selector to create a descendant combinator. If we only created a descendant combinator, the specificity would be tied with the div.text selector and it would come down to rule order, and if we only moved it the div.text selector would still have a higher specificity.
+  Then we added another selector to create a descendant combinator. If we only created a descendant combinator, the specificity would be tied with the
+  div.text selector and it would come down to rule order, and if we only moved it the div.text selector would still have a higher specificity.
   
   Another solution would be to keep the rule where it was and just replace the div selector with the .text selector:
 


### PR DESCRIPTION
Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [ ] I have ensured that the TOP solution files match the Desired Outcome image

<hr>

**1. Because:**
Additional solution has wrong px size and could potentially be confusing
Hard to read description 


**2. This PR:**
Changed 12px to 14px to match the correct px size
Wrapped lengthy description as instructed per TOP curriculum.


**3. Additional Information:**


