### PR TITLE
03-grid-layout-3: Remove a duplicate line of code from solution.css

### DIFF
--- a/grid/03-grid-layout-3/solution/solution.css
+++ b/grid/03-grid-layout-3/solution/solution.css
@@ -110,7 +110,6 @@
   display: grid;
   grid-template-columns: 1fr 4fr;
   gap: 4px;
-  text-align: center;
 }
 
 .header {


### PR DESCRIPTION
There is a text-align:center in the .container block under the /*SOLUTION*/ comment when there is already a text-align:center within the original .container block on line 7.

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get a pull request (PR) closed in a reasonable amount of time, you must include a baseline of information about the changes you are proposing. Please read this template in its entirety before filling it out to ensure that it is filled out correctly. -->

Complete the following REQUIRED checkboxes:
<!-- While editing this template, replace the whitespace between the square brackets with an 'x', e.g. [x] -->
-   [X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [X] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`

Complete the following checkbox ONLY IF it is applicable to your PR. You can complete it later if it is not currently applicable:
-   [ ] I have ensured that the TOP solution files match the Desired Outcome image

<hr>

**1. Because:**
<!--
If this PR closes an open issue, replace the XXXXX below with the issue number, e.g. Closes #2013. Or if the issue is in another TOP repo replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

Otherwise, provide a clear and concise reason for your pull request, e.g. what problem it solves or what benefit it provides. If this PR is related to, but does not close, another issue or PR, you can also link it as above without the 'Closes' keyword, e.g. "Related to #2013".
 -->
Solution.css contains two .container blocks. One with the original .container styling and the second below the comment SOLUTION with the additional solution .container styling. The line of code "text-align:center" is in both .container blocks. It should only be in the first one containing the original code as it was part of the orignal styling, and having it in the second .container block makes it a duplicate redundant declaration.  

**2. This PR:**
<!--
A bullet point list of one or more items outlining what was done in this PR to solve the problem(s) or implement the feature/enhancement.
 -->

-  The duplicate text-align:center was removed from the solution .container block. 

**3. Additional Information:**
<!-- Any additional information about the PR, such as a link to a Discord discussion, etc. -->
It seemed to be a minor issue so I did not discuss it in discord. 
