### PR TITLE
06-cascade-fix: Add missing weight from solution.css

### DIFF
--- a/foundations/06-cascade-fix/style.css
+++ b/foundations/06-cascade-fix/style.css
@@ -5,10 +5,12 @@ body{
 .para,
 .small-para {
   color: hsl(0, 0%, 0%);
+  font-weight: 800;
 }
 
 .small-para {
   font-size: 14px;
+  font-weight: 800;
 }
 
 .para {
@@ -29,6 +31,7 @@ body{
 
 .child {
   color: rgb(0, 0, 0);
+  font-weight: 800;
   font-size: 14px;
 }
 

--- a/foundations/06-cascade-fix/style.css
+++ b/foundations/06-cascade-fix/style.css
@@ -38,4 +38,5 @@ body{
 div.text {
   color: rgb(0, 0, 0);
   font-size: 22px;
+  font-weight: 100;
 }


### PR DESCRIPTION
[X] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
[X] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`

The solution.css has a font weight of 800 on the classes `.para, small-para`, `.small-para`, and `.child` that were missing from the originally assigned style.css
