### PR TITLE
02-class-id-selectors: Tweak note wording to make it clearer that desired-outcome.png isn't leading

### DIFF
--- a/foundations/02-class-id-selectors/README.md
+++ b/foundations/02-class-id-selectors/README.md
@@ -13,7 +13,7 @@ It isn't entirely important which class or ID values you use, as the focus here 
 Quick tip: in VS Code, you can change which format colors are displayed in RGB, HEX, or HSL by hovering over the color value in the CSS and clicking the top of the popup that appears!
 
 > ### Note:
-> Part of your task is to add a font to _some_ of these items. Do not worry about the font of the rest of them. Your browser's default font might be different than the one displayed and that's OK for this exercise.
+> Part of your task is to add a font to _some_ of these items. Your browser's font's might be different than the one displayed in the desired outcome image. As long as you confirm that the fonts _are_ being applied to the right lines any differences are okay for this exercise.
 
 ## Desired Outcome
 ![desired outcome](./desired-outcome.png)


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
There is often confusion about whether or not students have solved 02-class-id-selectors correctly, as the final display of index.html can vary wildly based on which fonts the student has installed. 


## This PR
* Tweaks the wording of the 02-class-id-selectors note to make it clear that as long as the fonts are being properly added it doesn't matter if desired-outcome.png looks different.

## Additional Information
Discussed on Discord at https://discord.com/channels/505093832157691914/1041342225201778769

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/theodinproject/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR