### PR TITLE
flex: 06-flex-layout: README.md: Improve self check clarity

### DIFF
--- a/flex/06-flex-layout/solution/solution.css
+++ b/flex/06-flex-layout/solution/solution.css
@@ -23,7 +23,6 @@ input {
   border-radius: 16px;
   padding: 8px 24px;
   width: 400px;
-  margin-bottom: 16px;
 }
 
 /* SOLUTION */
@@ -43,6 +42,7 @@ button {
   align-items: center;
   justify-content: center;
   flex-direction: column;
+  gap: 16px;
 }
 
 a {


### PR DESCRIPTION
- This is to keep with the flex spirit
- Another solution might instead be to nest .input and .buttons into their own container, then apply the gap property to that container. This solves the visually uneven spacing between <img> and .input

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

README.md says "There is space between the logo, input and buttons", but the related solution.css only gives space between the input and buttons via "margin-bottom: 16px;" applied to .input

This improves clarity of the README.md "Self Check" section by adding actual CSS "space between the logo, input and buttons", instead of the current arrangement with space only between the input and buttons. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- remove `margin-bottom: 16px;` from `.input`
- use `gap: 16px` instead on their container: `.content`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->

Closes #349

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, I have ensured that the TOP solution files match the Desired Outcome image
