### PR TITLE
02-flex-header: Match the solution font with the desired image

### DIFF
--- a/flex/02-flex-header/README.md
+++ b/flex/02-flex-header/README.md
@@ -16,3 +16,5 @@ wide:
 - list-items are horizontal, and are centered vertically inside the header.
 - left-links and right-links are pushed all the way to the left and right, and stay at the edge of the header when the page is resized.
 - Your solution does not use floats, inline-block, or absolute positioning.
+
+- Note: For this exercise, it's completely acceptable to not match the font-family.

--- a/flex/02-flex-header/solution/solution.css
+++ b/flex/02-flex-header/solution/solution.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap');
+
 .header  {
   font-family: monospace;
   background: papayawhip;
@@ -27,6 +29,8 @@ a {
 /* SOLUTION */
 
 .header {
+  /* Feel free to not worry too heavily on matching the font  */
+  font-family: 'Courier Prime', monospace;
   padding: 8px;
   display: flex;
   align-items: center;
@@ -38,4 +42,8 @@ ul {
   margin: 0;
   padding: 0;
   gap: 8px;
+}
+
+a {
+  font-weight: 400;
 }

--- a/flex/02-flex-header/solution/solution.css
+++ b/flex/02-flex-header/solution/solution.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Courier+Prime:wght@400;700&display=swap');
-
 .header  {
   font-family: monospace;
   background: papayawhip;
@@ -29,8 +27,6 @@ a {
 /* SOLUTION */
 
 .header {
-  /* Feel free to not worry too heavily on matching the font  */
-  font-family: 'Courier Prime', monospace;
   padding: 8px;
   display: flex;
   align-items: center;
@@ -42,8 +38,4 @@ ul {
   margin: 0;
   padding: 0;
   gap: 8px;
-}
-
-a {
-  font-weight: 400;
 }


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
- The font in the desired image varies when compared with the solution's font.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->
- Added the specific font in the `solution.html`

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #458 

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
- Note: The `import` statement needs to be at the top of `css` file, so it couldn't be placed after `/* SOLUTION */` comment

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, I have ensured that the TOP solution files match the Desired Outcome image
