### PR TITLE
Repo README: Improve wording regarding TOP provided solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you have suggestions to improve an exercise, ideas for a new exercise, or not
     * Depending on the instructions of the exercise, you may only need to make edits in one of these files.
 5. Once you successfully finish an exercise, check TOP's solution to compare it with yours.
    * You should not be checking the solution for an exercise until you finish it!
-   * Keep in mind that TOP's solution is not the only solution. If your solution differs wildly from TOP's solution (and still passes the self-check criteria), feel free to ask about it in the chatroom.
+   * If your solution differs wildly from TOP's solution (and still passes the self-check criteria), that's completely fine. Do feel free to ask about it in the chatroom if there are parts you do not understand.
 6. Do not submit your solutions to this repo, as any PRs that do so will be closed without merging.
 
 ## Some Hints

--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ If you have suggestions to improve an exercise, ideas for a new exercise, or not
 ## How To Use These Exercises
 
 1. Fork and clone this repository. To learn how to fork a repository, see the GitHub documentation on how to [fork a repo](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
-    * Copies of repositories on your machine are called clones. If you need help cloning to your local environment, you can learn how from the GitHub documentation on [cloning a repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository).
-2. Go to an exercise directory and open the HTML file in a web browser. You can open the file directly or use something like VSCode's Live Server extension.
-3. For each exercise, read the README thoroughly before starting any work.
-    * Each README has a "Self Check" list. Use this to ensure you haven't missed any important details in your implementation.
-4. Make your edits in the `index.html` and/or the `style.css` files in order to make the output in your browser look like the Desired Outcome image(s).
-    * Depending on the instructions of the exercise, you may only need to make edits in one of these files.
-5. Once you successfully finish an exercise, check TOP's solution to compare it with yours.
-   * You should not be checking the solution for an exercise until you finish it!
-   * If your solution differs wildly from TOP's solution (and still passes the self-check criteria), that's completely fine. Do feel free to ask about it in the chatroom if there are parts you do not understand.
-6. Do not submit your solutions to this repo, as any PRs that do so will be closed without merging.
+    - Copies of repositories on your machine are called clones. If you need help cloning to your local environment, you can learn how from the GitHub documentation on [cloning a repository](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository).
+1. Go to an exercise directory and open the HTML file in a web browser. You can open the file directly or use something like VSCode's Live Server extension.
+1. For each exercise, read the README thoroughly before starting any work.
+    - Each README has a "Self Check" list. Use this to ensure you haven't missed any important details in your implementation.
+1. Make your edits in the `index.html` and/or the `style.css` files in order to make the output in your browser look like the Desired Outcome image(s).
+    - Depending on the instructions of the exercise, you may only need to make edits in one of these files.
+1. Once you successfully finish an exercise, check TOP's solution to compare it with yours.
+    - You should not be checking the solution for an exercise until you finish it!
+    - If your solution differs wildly from TOP's solution (and still passes the exercise's requirements), that's completely fine. Do feel free to ask about it in our Discord if there are parts you do not understand.
+1. Do not submit your solutions to this repo, as any PRs that do so will be closed without merging.
 
 ## Some Hints
 - The official solutions put all changes at the _end_ of the CSS file, which may duplicate some selectors (e.g. there might be a `body {}` in the given CSS and another `body {}` in the solution). When you are working on an exercise, it is best practice to add your CSS to existing selectors instead of duplicating them at the end of the file. We're sacrificing this best practice in our official solutions to make it extra clear to you what things we changed to solve the exercise.


### PR DESCRIPTION
## Because
People are very commonly concerned when they see their exercise solutions differ from the provided solutions. This is primarily from two parts:
- Learners are initially directed straight to the relevant exercise directory and not told to read the repo README (where a note about the provided solution is). *This has been addressed in [#27055](https://github.com/TheOdinProject/curriculum/pull/27055)*
- The README note on provided solutions, despite saying the provided one isn't the only solution, the rest of the sentence seems to be interpret-able as "if your solution differs, check with the community if it's actually allowed".


## This PR
- Improves the wording of the relevant README note to clarify intent (unified wording with `javascript-exercises` repo)


## Issue
Closes [#27053](https://github.com/TheOdinProject/curriculum/issues/27053)

## Additional Information
In conjunction with [#424](https://github.com/TheOdinProject/javascript-exercises/pull/424) from the `css-exercises` repo


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, I have ensured that the TOP solution files match the Desired Outcome image
