### PR TITLE
07-flex-layout-2: Add gap to container class instead of adding margin to card class in solution.css

### DIFF
--- a/flex/07-flex-layout-2/solution/solution.css
+++ b/flex/07-flex-layout-2/solution/solution.css
@@ -73,7 +73,7 @@ a {
   padding: 32px;
   display: flex;
   flex-wrap: wrap;
-  gap: 16px;
+  gap: 32px;
 }
 
 .card {

--- a/flex/07-flex-layout-2/solution/solution.css
+++ b/flex/07-flex-layout-2/solution/solution.css
@@ -70,7 +70,7 @@ a {
 }
 
 .container {
-  padding: 32px;
+  padding: 48px;
   display: flex;
   flex-wrap: wrap;
   gap: 32px;

--- a/flex/07-flex-layout-2/solution/solution.css
+++ b/flex/07-flex-layout-2/solution/solution.css
@@ -73,11 +73,11 @@ a {
   padding: 32px;
   display: flex;
   flex-wrap: wrap;
+  gap: 16px;
 }
 
 .card {
   padding: 16px;
-  margin: 16px;
   width: 300px;
 }
 


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->

In `solution.css`, adding `gap` property to the parent `.container` class, instead of adding margin to the child `.card` class since we are using `Flexbox` for creating the cards. 

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Removing `margin: 16px`  from the `.card` class.
- Instead, adding `gap: 16px` property to the `.container` class to give space between the cards.


## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
### Output

<img width="1440" alt="Screenshot 2024-03-08 at 7 27 19 PM" src="https://github.com/TheOdinProject/css-exercises/assets/154410453/6a441f12-c5f5-455a-a1c7-c289a659f7d0">



## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If applicable, I have ensured that the TOP solution files match the Desired Outcome image
