### PR TITLE
05-descendant-combinator: Remove child combinator from solution.css

### DIFF
--- a/foundations/05-descendant-combinator/solution/solution.css
+++ b/foundations/05-descendant-combinator/solution/solution.css
@@ -8,7 +8,6 @@
 /* Below are some other possible descendant combinators:
 
 div p
-div > p
 div .text
 .container p
 


### PR DESCRIPTION
## Because
The div > p option in `solution.css` file is listed as a possible descendant combinator. According to MDN, it is not a descendant combinator, and it actually enforces stricter inheritance between parent and child element relationships, therefore it should not be listed as a possible combinator.


## This PR
- Removes child combinator from the list of possible descendant combinators

## Issue
Closes [#558](https://github.com/TheOdinProject/css-exercises/issues/558)

## Additional Information
None.

## Pull Request Requirements
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, I have ensured that the TOP solution files match the Desired Outcome image
