### PR TITLE
03-grouping-selectors: Update CSS solutions and README.md for grouping selectors

### DIFF
--- a/foundations/03-grouping-selectors/README.md
+++ b/foundations/03-grouping-selectors/README.md
@@ -4,15 +4,16 @@ Let's build a little off the previous exercise. Here, you're going to give two e
 
 This will help you further practice adding classes and using class selectors, so be sure you add the class attribute in the HTML file. For the remainder of these exercises, the format of any colors is entirely up to you; we trust you'll practice using the different values! The properties you need to add to each element are:
 
-* **The first element**: a black background, white text color, and a bold font weight
-* **The second element**: a yellow background
-* **Both elements**: a font size of 28px and a list of fonts containing `Helvetica` and `Times New Roman`, with `sans-serif` as a fallback 
+- **The first element**: a black background and white text
+- **The second element**: a yellow background
+- **Both elements**: a font size of 28px and a list of fonts containing `Helvetica` and `Times New Roman`, with `sans-serif` as a fallback
 
 ## Desired Outcome
+
 ![desired outcome](./desired-outcome.png)
 
-
 ### Self Check
+
 - Does each element have a unique class name?
 - Did you use the grouping selector for styles that both elements share?
 - Did you make separate rules for the styles unique to each element?

--- a/foundations/03-grouping-selectors/solution/solution.css
+++ b/foundations/03-grouping-selectors/solution/solution.css
@@ -1,4 +1,3 @@
-
 .inverted,
 .fancy {
   font-family: Helvetica, "Times New Roman", sans-serif;
@@ -8,7 +7,6 @@
 .inverted {
   background-color: black;
   color: white;
-  font-weight: bold;
 }
 
 .fancy {


### PR DESCRIPTION
<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
In the [Grouping Selectors](https://github.com/TheOdinProject/css-exercises/tree/main/foundations/03-grouping-selectors) module of the `foundations` folder, the desired-outcome.png file (and thus the README.md image) does not correctly convey the bold weight of the first button. This PR undoes the work done in #355, and fixes the expectation of having a bold button.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Removes the bold requirement from README.md,
- Modifies the solution CSS.

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #559

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->
None.

## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, I have ensured that the TOP solution files match the Desired Outcome image
