### PR TITLE
01-cascade-fix: Clarify multiple solutions in README

### DIFF
--- a/foundations/cascade/01-cascade-fix/README.md
+++ b/foundations/cascade/01-cascade-fix/README.md
@@ -4,7 +4,7 @@ This final exercise for CSS Foundations is going to give you a closer look at th
 
 There are a few elements that have some sort of specificity or rule order issue in the provided CSS file. It's up to you to figure out what issue is affecting an element, and how to fix it. You can edit the CSS file by adding, removing, or editing selectors for a declaration block, or by moving declaration blocks around. **You should not edit the HTML file or any of the actual styles in the CSS**.
 
-There are multiple ways to solve this exercise, and we did our best to include all of the possible solutions for each element.
+There are multiple ways to solve this exercise, so we have provided some of the possible solutions for each element.
 
 Issues with the cascade can be the bane of their existence for many when it comes to CSS. While you won't become a cascade expert from this exercise alone, and there are other ways to deal with these issues, it is still super helpful to see how these issues affect our final styles and why it's important to order rules carefully.
 

--- a/foundations/cascade/01-cascade-fix/solution/solution.css
+++ b/foundations/cascade/01-cascade-fix/solution/solution.css
@@ -86,6 +86,14 @@ div.text {
 
   Then we added another selector to create a descendant combinator. If we only created a descendant combinator, the specificity would be tied with the
   div.text selector and it would come down to rule order, and if we only moved it, the div.text selector would still have a higher specificity.
+
+  The last explanation is also applicable if, instead of creating a descendant combinator, we had chained both selectors:
+  
+  div.child {
+    color: rgb(0, 0, 0);
+    font-weight: 800;
+    font-size: 14px;
+  }
   
   Another solution would be to keep the rule where it was and just replace the div selector with the .text selector:
 

--- a/foundations/cascade/01-cascade-fix/solution/solution.css
+++ b/foundations/cascade/01-cascade-fix/solution/solution.css
@@ -86,14 +86,6 @@ div.text {
 
   Then we added another selector to create a descendant combinator. If we only created a descendant combinator, the specificity would be tied with the
   div.text selector and it would come down to rule order, and if we only moved it, the div.text selector would still have a higher specificity.
-
-  The last explanation is also applicable if, instead of creating a descendant combinator, we had chained both selectors:
-  
-  div.child {
-    color: rgb(0, 0, 0);
-    font-weight: 800;
-    font-size: 14px;
-  }
   
   Another solution would be to keep the rule where it was and just replace the div selector with the .text selector:
 


### PR DESCRIPTION
A new way to solve the last part of the CSS Cascade exercise has been added, as a comment, in the solution file solution.css. That last part refers to the last rules to be modified (div.text and .child).

<!-- Thank you for taking the time to contribute to The Odin Project. In order to get this pull request (PR) merged in a reasonable amount of time, you must complete this entire template. -->

## Because
<!-- Summarize the purpose or reasons for this PR, e.g. what problem it solves or what benefit it provides. -->
The README.md file in the 01-cascade-fix exercise says that all possible solutions to the exercise would be included (or at least it would try to do it). As I saw another possible solution for the last part of the exercise (div.text & .child associated rules), I decided to include it in the solution.css file.

## This PR
<!-- A bullet point list of one or more items describing the specific changes. -->

- Under the explanation in line 87 of solution.css:

> _Then we added another selector to create a descendant combinator. If we only created a descendant combinator, the specificity would be tied with the div.text selector and it would come down to rule order, and if we only moved it, the div.text selector would still have a higher specificity_

...I have added the following comment explaining an additional solution that is also valid: 

> _The last explanation is also applicable if, instead of creating a descendant combinator, we had chained both selectors:_
>   
>   _div.child {
>     color: rgb(0, 0, 0);
>     font-weight: 800;
>     font-size: 14px;
>   }_

## Issue
<!--
If this PR closes an open issue in this repo, replace the XXXXX below with the issue number, e.g. Closes #2013.

If this PR closes an open issue in another TOP repo, replace the #XXXXX with the URL of the issue, e.g. Closes https://github.com/TheOdinProject/curriculum/issues/XXXXX

If this PR does not close, but is related to another issue or PR, you can link it as above without the 'Closes' keyword, e.g. 'Related to #2013'.
-->
Closes #XXXXX

## Additional Information
<!-- Any other information about this PR, such as a link to a Discord discussion. -->


## Pull Request Requirements
<!-- Replace the whitespace between the square brackets with an 'x', e.g. [x]. After you create the PR, they will become checkboxes that you can click on. -->
-   [x] I have thoroughly read and understand [The Odin Project Contributing Guide](https://github.com/TheOdinProject/.github/blob/main/CONTRIBUTING.md)
-   [x] The title of this PR follows the `location of change: brief description of change` format, e.g. `01-flex-center: Update self check`
-   [x] The `Because` section summarizes the reason for this PR
-   [x] The `This PR` section has a bullet point list describing the changes in this PR
-   [x] If this PR addresses an open issue, it is linked in the `Issue` section
-   [x] If applicable, I have ensured that the TOP solution files match the Desired Outcome image
